### PR TITLE
Add longer timeout and sleep for timeout tests

### DIFF
--- a/internal/interopconnect/test_cases.go
+++ b/internal/interopconnect/test_cases.go
@@ -187,7 +187,7 @@ func DoEmptyStream(t crosstesting.TB, client connectpb.TestServiceClient) {
 
 // DoTimeoutOnSleepingServer performs an RPC on a sleep server which causes RPC timeout.
 func DoTimeoutOnSleepingServer(t crosstesting.TB, client connectpb.TestServiceClient) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	stream := client.FullDuplexCall(ctx)
 	assert.NotNil(t, stream)
@@ -207,6 +207,7 @@ func DoTimeoutOnSleepingServer(t crosstesting.TB, client connectpb.TestServiceCl
 		return
 	}
 	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
 	_, err = stream.Receive()
 	assert.Error(t, err)
 	assert.Equal(t, connect.CodeOf(err), connect.CodeDeadlineExceeded)

--- a/internal/interopgrpc/test_cases.go
+++ b/internal/interopgrpc/test_cases.go
@@ -199,7 +199,7 @@ func DoEmptyStream(t crosstesting.TB, client testpb.TestServiceClient, args ...g
 
 // DoTimeoutOnSleepingServer performs an RPC on a sleep server which causes RPC timeout.
 func DoTimeoutOnSleepingServer(t crosstesting.TB, client testpb.TestServiceClient, args ...grpc.CallOption) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	stream, err := client.FullDuplexCall(ctx, args...)
 	if err != nil {
@@ -218,6 +218,7 @@ func DoTimeoutOnSleepingServer(t crosstesting.TB, client testpb.TestServiceClien
 	}
 	err = stream.Send(req)
 	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
 	_, err = stream.Recv()
 	assert.Equal(t, status.Code(err), codes.DeadlineExceeded)
 	t.Successf("successful timeout on sleep")


### PR DESCRIPTION
This adds a longer timeout on the client-side
for the timeout tests and then sleeps on the
client-side before attempting to Receive from
the BiDi stream. This should reinforce the behaviour
we want, which is testing for a timeout _after_ the
first send but before the first receive.

Fixes #127