### PR TITLE
Add `connect-*` headers from the Connect protocol to Envoy CORs policy

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -31,7 +31,7 @@ static_resources:
                         allow_origin_string_match:
                           - prefix: "*"
                         allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-grpc-test-echo-initial,x-grpc-test-echo-trailing-bin,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-grpc-test-echo-initial,x-grpc-test-echo-trailing-bin,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-timeout-ms,connect-content-encoding,connect-accept-encoding
                         max_age: "1728000"
                         expose_headers: x-grpc-test-echo-initial,x-grpc-test-echo-trailing-bin,grpc-status,grpc-message
                 http_filters:


### PR DESCRIPTION
The latest runs of crosstests now use the Connect protocol implementation
for `connect-web`, and so for web tests that use the Envoy proxy, the
CORs policies need to be updated for our Envoy config.
