### PR TITLE
Remove gRPC and gRPC-web test cases against h3 server until trailer support is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,8 @@ endif
 	docker-compose run client-connect-to-server-connect-h3
 	docker-compose run client-connect-grpc-to-server-connect-h1
 	docker-compose run client-connect-grpc-to-server-connect-h2
-	docker-compose run client-connect-grpc-to-server-connect-h3
 	docker-compose run client-connect-grpc-web-to-server-connect-h1
 	docker-compose run client-connect-grpc-web-to-server-connect-h2
-	docker-compose run client-connect-grpc-web-to-server-connect-h3
 	docker-compose run client-connect-grpc-to-server-grpc
 	docker-compose run client-grpc-to-server-connect
 	docker-compose run client-grpc-to-server-grpc

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -91,7 +91,7 @@ func bind(cmd *cobra.Command, flags *flags) error {
 		"i",
 		"",
 		fmt.Sprintf(
-			"the client implementation tested, accepted values are %q, %q, %q, %q, %q, %q, %q, or %q",
+			"the client implementation tested, accepted values are %q, %q, %q, %q, %q, %q, %q, %q, or %q",
 			connectH1,
 			connectH2,
 			connectH3,

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -53,10 +53,8 @@ const (
 	connectH3        = "connect-h3"
 	connectGRPCH1    = "connect-grpc-h1"
 	connectGRPCH2    = "connect-grpc-h2"
-	connectGRPCH3    = "connect-grpc-h3"
 	connectGRPCWebH1 = "connect-grpc-web-h1"
 	connectGRPCWebH2 = "connect-grpc-web-h2"
-	connectGRPCWebH3 = "connect-grpc-web-h3"
 	grpcGo           = "grpc-go"
 )
 
@@ -92,16 +90,14 @@ func bind(cmd *cobra.Command, flags *flags) error {
 		"i",
 		"",
 		fmt.Sprintf(
-			"the client implementation tested, accepted values are %q, %q, %q, %q, %q, %q, %q, %q, %q, or %q",
+			"the client implementation tested, accepted values are %q, %q, %q, %q, %q, %q, %q, or %q",
 			connectH1,
 			connectH2,
 			connectH3,
 			connectGRPCH1,
 			connectGRPCH2,
-			connectGRPCH3,
 			connectGRPCWebH1,
 			connectGRPCWebH2,
-			connectGRPCWebH3,
 			grpcGo,
 		),
 	)
@@ -212,15 +208,12 @@ func run(flags *flags) {
 		)
 	// For tests that depend on trailers, we only run them for HTTP2, since the HTTP3 client
 	// does not yet have trailers support https://github.com/lucas-clemente/quic-go/issues/2266
-	case connectH3, connectGRPCH3, connectGRPCWebH3:
+	// connectGRPCH3 and connectGRPCWebH3 have both been disabled since we are now strictly
+	// requiring `grpc-status` headers to be set on response, which requires trailer support.
+	// Once trailer support is available, they will be renabled.
+	case connectH3:
 		// add client option if the implementation is grpc or grpc-web
 		var clientOptions []connect.ClientOption
-		switch flags.implementation {
-		case connectGRPCH3:
-			clientOptions = append(clientOptions, connect.WithGRPC())
-		case connectGRPCWebH3:
-			clientOptions = append(clientOptions, connect.WithGRPCWeb())
-		}
 		transport := &http3.RoundTripper{
 			TLSClientConfig: newTLSConfig(flags.certFile, flags.keyFile),
 		}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -214,11 +214,11 @@ func run(flags *flags) {
 	// requiring `grpc-status` headers to be set on response, which requires trailer support.
 	// Once trailer support is available, they will be renabled.
 	case connectH3, connectGRPCWebH3:
+		// add client option if the implementation is grpc or grpc-web
+		var clientOptions []connect.ClientOption
 		if flags.implementation == connectGRPCWebH3 {
 			clientOptions = append(clientOptions, connect.WithGRPCWeb())
 		}
-		// add client option if the implementation is grpc or grpc-web
-		var clientOptions []connect.ClientOption
 		transport := &http3.RoundTripper{
 			TLSClientConfig: newTLSConfig(flags.certFile, flags.keyFile),
 		}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -55,6 +55,7 @@ const (
 	connectGRPCH2    = "connect-grpc-h2"
 	connectGRPCWebH1 = "connect-grpc-web-h1"
 	connectGRPCWebH2 = "connect-grpc-web-h2"
+	connectGRPCWebH3 = "connect-grpc-web-h3"
 	grpcGo           = "grpc-go"
 )
 
@@ -98,6 +99,7 @@ func bind(cmd *cobra.Command, flags *flags) error {
 			connectGRPCH2,
 			connectGRPCWebH1,
 			connectGRPCWebH2,
+			connectGRPCWebH3,
 			grpcGo,
 		),
 	)
@@ -211,7 +213,10 @@ func run(flags *flags) {
 	// connectGRPCH3 and connectGRPCWebH3 have both been disabled since we are now strictly
 	// requiring `grpc-status` headers to be set on response, which requires trailer support.
 	// Once trailer support is available, they will be renabled.
-	case connectH3:
+	case connectH3, connectGRPCWebH3:
+		if flags.implementation == connectGRPCWebH3 {
+			clientOptions = append(clientOptions, connect.WithGRPCWeb())
+		}
 		// add client option if the implementation is grpc or grpc-web
 		var clientOptions []connect.ClientOption
 		transport := &http3.RoundTripper{


### PR DESCRIPTION
Since we are adding strict reinforcement of `grpc-status` headers,
we cannot run gRPC and gRPC client tests against the h3 server
until trailer support is available.
