### PR TITLE
test servers health check on spin up and envoy depends on test servers

### DIFF
--- a/Dockerfile.crosstest
+++ b/Dockerfile.crosstest
@@ -19,10 +19,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -o /go/bin/servergrpc ./cmd/servergrpc
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11
 
 FROM --platform=${TARGETPLATFORM} alpine:3.16.1
 
 COPY --from=builder /go/bin/client /usr/local/bin/client
 COPY --from=builder /go/bin/serverconnect /usr/local/bin/serverconnect
 COPY --from=builder /go/bin/servergrpc /usr/local/bin/servergrpc
+COPY --from=builder /go/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
 COPY --from=builder /workspace/cert /cert

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ checkgenerate:
 
 .PHONY: dockercomposetestgo
 dockercomposetestgo: dockercomposeclean
+	docker-compose run -d server-connect
+	docker-compose run -d server-grpc
 	docker-compose run client-connect-to-server-connect-h1
 	docker-compose run client-connect-to-server-connect-h2
 	docker-compose run client-connect-to-server-connect-h3
@@ -95,6 +97,9 @@ dockercomposetestgo: dockercomposeclean
 
 .PHONY: dockercomposetestweb
 dockercomposetestweb: dockercomposeclean
+	docker-compose run -d server-connect
+	docker-compose run -d server-grpc
+	docker-compose run -d envoy
 	docker-compose run client-web-connect-web-to-server-connect-h1
 	docker-compose run client-web-connect-grpc-web-to-server-connect-h1
 	docker-compose run client-web-connect-grpc-web-to-envoy-server-connect

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,6 @@ checkgenerate:
 
 .PHONY: dockercomposetestgo
 dockercomposetestgo: dockercomposeclean
-	docker-compose run -d server-connect
-	docker-compose run -d server-grpc
 	docker-compose run client-connect-to-server-connect-h1
 	docker-compose run client-connect-to-server-connect-h2
 	docker-compose run client-connect-to-server-connect-h3
@@ -97,9 +95,6 @@ dockercomposetestgo: dockercomposeclean
 
 .PHONY: dockercomposetestweb
 dockercomposetestweb: dockercomposeclean
-	docker-compose run -d server-connect
-	docker-compose run -d server-grpc
-	docker-compose run -d envoy
 	docker-compose run client-web-connect-web-to-server-connect-h1
 	docker-compose run client-web-connect-grpc-web-to-server-connect-h1
 	docker-compose run client-web-connect-grpc-web-to-envoy-server-connect

--- a/cmd/serverconnect/main.go
+++ b/cmd/serverconnect/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bufbuild/connect-crosstest/internal/gen/proto/connect/grpc/testing/testingconnect"
 	serverpb "github.com/bufbuild/connect-crosstest/internal/gen/proto/go/server/v1"
 	"github.com/bufbuild/connect-crosstest/internal/interop/interopconnect"
+	grpchealth "github.com/bufbuild/connect-grpchealth-go"
 	"github.com/lucas-clemente/quic-go/http3"
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
@@ -84,6 +85,10 @@ func bind(cmd *cobra.Command, flagset *flags) error {
 
 func run(flags *flags) {
 	mux := http.NewServeMux()
+	checker := grpchealth.NewStaticChecker(
+		testingconnect.TestServiceName,
+	)
+	mux.Handle(grpchealth.NewHandler(checker))
 	mux.Handle(testingconnect.NewTestServiceHandler(
 		interopconnect.NewTestServiceHandler(),
 	))

--- a/cmd/servergrpc/main.go
+++ b/cmd/servergrpc/main.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // this register the gzip compressor to the grpc server
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -101,6 +103,9 @@ func run(flagset *flags) {
 	}
 	_, _ = fmt.Fprintln(os.Stdout, string(bytes))
 	testrpc.RegisterTestServiceServer(server, interopgrpc.NewTestServer())
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus(testrpc.TestService_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
 	_ = server.Serve(lis)
 	defer server.GracefulStop()
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,11 @@ services:
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
       - ./cert:/cert/:ro
+    depends_on:
+      server-connect:
+        condition: service_healthy
+      server-grpc:
+        condition: service_healthy
   client-connect-to-server-connect-h1:
     build:
       context: .
@@ -189,10 +194,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="connect-grpc-web"
     depends_on:
-      envoy:
-        condition: service_started
-      server-connect:
-        condition: service_healthy
+      - envoy
   client-web-connect-grpc-web-to-envoy-server-grpc:
     build:
       context: .
@@ -202,10 +204,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="connect-grpc-web"
     depends_on:
-      envoy:
-        condition: service_started
-      server-grpc:
-        condition: service_healthy
+      - envoy
   client-web-grpc-web-to-server-connect-h1:
     build:
       context: .
@@ -226,10 +225,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="grpc-web"
     depends_on:
-      envoy:
-        condition: service_started
-      server-connect:
-        condition: service_healthy
+      - envoy
   client-web-grpc-web-to-envoy-server-grpc:
     build:
       context: .
@@ -239,7 +235,4 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="grpc-web"
     depends_on:
-      envoy:
-        condition: service_started
-      server-grpc:
-        condition: service_healthy
+      - envoy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
       - "8080:8080"
       - "8081:8081"
       - "8082:8082"
+    healthcheck:
+      test: [ "CMD", "/usr/local/bin/grpc-health-probe", "-addr=localhost:8081", "-service=grpc.testing.TestService", "-tls", "-tls-ca-cert=cert/CrosstestCA.crt", "-tls-server-name=server-connect"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
   server-grpc:
     build:
       context: .
@@ -20,6 +25,11 @@ services:
     entrypoint: /usr/local/bin/servergrpc --port "8083" --cert "cert/server-grpc.crt" --key "cert/server-grpc.key"
     ports:
       - "8083:8083"
+    healthcheck:
+      test: [ "CMD", "/usr/local/bin/grpc-health-probe", "-addr=localhost:8083", "-service=grpc.testing.TestService", "-tls", "-tls-ca-cert=cert/CrosstestCA.crt", "-tls-server-name=server-grpc"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
   envoy:
     image: envoyproxy/envoy:v1.20-latest
     ports:
@@ -36,7 +46,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8080" --implementation="connect-h1" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-to-server-connect-h2:
     build:
       context: .
@@ -45,7 +56,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-to-server-connect-h3:
     build:
       context: .
@@ -54,7 +66,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-to-server-connect-h1:
     build:
       context: .
@@ -63,7 +76,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8080" --implementation="connect-grpc-h1" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-to-server-connect-h2:
     build:
       context: .
@@ -72,7 +86,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-grpc-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-to-server-connect-h3:
     build:
       context: .
@@ -81,7 +96,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-grpc-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-web-to-server-connect-h1:
     build:
       context: .
@@ -90,7 +106,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8080" --implementation="connect-grpc-web-h1" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-web-to-server-connect-h2:
     build:
       context: .
@@ -99,7 +116,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-grpc-web-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-web-to-server-connect-h3:
     build:
       context: .
@@ -108,7 +126,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-grpc-web-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-connect-grpc-to-server-grpc:
     build:
       context: .
@@ -117,7 +136,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-grpc" --port="8083" --implementation="connect-grpc-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-grpc
+      server-grpc:
+        condition: service_healthy
   client-grpc-to-server-connect:
     build:
       context: .
@@ -126,7 +146,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="grpc-go" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-grpc-to-server-grpc:
     build:
       context: .
@@ -135,7 +156,8 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-grpc" --port="8083" --implementation="grpc-go" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      - server-grpc
+      server-grpc:
+        condition: service_healthy
   client-web-connect-web-to-server-connect-h1:
     build:
       context: .
@@ -145,7 +167,8 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="server-connect" --port="8080" --implementation="connect-web"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-web-connect-grpc-web-to-server-connect-h1:
     build:
       context: .
@@ -155,7 +178,8 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="server-connect" --port="8080" --implementation="connect-grpc-web"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-web-connect-grpc-web-to-envoy-server-connect:
     build:
       context: .
@@ -165,8 +189,10 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="connect-grpc-web"
     depends_on:
-      - server-connect
-      - envoy
+      envoy:
+        condition: service_started
+      server-connect:
+        condition: service_healthy
   client-web-connect-grpc-web-to-envoy-server-grpc:
     build:
       context: .
@@ -176,8 +202,10 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="connect-grpc-web"
     depends_on:
-      - server-grpc
-      - envoy
+      envoy:
+        condition: service_started
+      server-grpc:
+        condition: service_healthy
   client-web-grpc-web-to-server-connect-h1:
     build:
       context: .
@@ -187,7 +215,8 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="server-connect" --port="8080" --implementation="grpc-web"
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy
   client-web-grpc-web-to-envoy-server-connect:
     build:
       context: .
@@ -197,8 +226,10 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="grpc-web"
     depends_on:
-      - server-connect
-      - envoy
+      envoy:
+        condition: service_started
+      server-connect:
+        condition: service_healthy
   client-web-grpc-web-to-envoy-server-grpc:
     build:
       context: .
@@ -208,5 +239,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="grpc-web"
     depends_on:
-      - server-grpc
-      - envoy
+      envoy:
+        condition: service_started
+      server-grpc:
+        condition: service_healthy

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/bufbuild/connect-go v0.3.0
+	github.com/bufbuild/connect-grpchealth-go v0.1.0
 	github.com/lucas-clemente/quic-go v0.28.1
 	github.com/rs/cors v1.8.2
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bufbuild/connect-go v0.3.0 h1:B0vyZrTR11SNEYpodL6P0NzluDCsuqmr8CNKblXvVto=
 github.com/bufbuild/connect-go v0.3.0/go.mod h1:4efZ2eXFENwd4p7tuLaL9m0qtTsCOzuBvrohvRGevDM=
+github.com/bufbuild/connect-grpchealth-go v0.1.0 h1:r3HMBCXkqocR7z1ET98kteRE5K4B84lP9XMCRQXIGmw=
+github.com/bufbuild/connect-grpchealth-go v0.1.0/go.mod h1:Vm0Mk9/DurVa0pThTknZTXTzzfNio6EDpU64SP4JONc=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
this minimized the chance of web client test getting flaky no healthy upstream error, the issue is that docker-compose `depends_on` config doesn't guarantee the server is ready for request. It wasn't an issue when the tests of go and web are running together as the go tests were run first, so by the time the web tests start all server should already be ready for request. Attempted multiple way (e.g check connection before starting the test, setup retry policy in envoy) and this seems to be the most reasonable way to do this for now.

update:
turns out there is also an issue within envoy, where the envoy didn't depends on the connect and grpc test server, so the dns resolution for the server that not spin up yet will fail, and when we spin up the test server and start the test, the dns resolution might not be refreshed yet as it has a 5000ms refresh rate. updated envoy to depends on both servers, and the test clients only depends on envoy