### PR TITLE
revert test servers health check

### DIFF
--- a/Dockerfile.crosstest
+++ b/Dockerfile.crosstest
@@ -19,14 +19,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -o /go/bin/servergrpc ./cmd/servergrpc
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11
 
 FROM --platform=${TARGETPLATFORM} alpine:3.16.1
 
 COPY --from=builder /go/bin/client /usr/local/bin/client
 COPY --from=builder /go/bin/serverconnect /usr/local/bin/serverconnect
 COPY --from=builder /go/bin/servergrpc /usr/local/bin/servergrpc
-COPY --from=builder /go/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
 COPY --from=builder /workspace/cert /cert

--- a/cmd/serverconnect/main.go
+++ b/cmd/serverconnect/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/bufbuild/connect-crosstest/internal/gen/proto/connect/grpc/testing/testingconnect"
 	serverpb "github.com/bufbuild/connect-crosstest/internal/gen/proto/go/server/v1"
 	"github.com/bufbuild/connect-crosstest/internal/interop/interopconnect"
-	grpchealth "github.com/bufbuild/connect-grpchealth-go"
 	"github.com/lucas-clemente/quic-go/http3"
 	"github.com/rs/cors"
 	"github.com/spf13/cobra"
@@ -85,10 +84,6 @@ func bind(cmd *cobra.Command, flagset *flags) error {
 
 func run(flags *flags) {
 	mux := http.NewServeMux()
-	checker := grpchealth.NewStaticChecker(
-		testingconnect.TestServiceName,
-	)
-	mux.Handle(grpchealth.NewHandler(checker))
 	mux.Handle(testingconnect.NewTestServiceHandler(
 		interopconnect.NewTestServiceHandler(),
 	))

--- a/cmd/servergrpc/main.go
+++ b/cmd/servergrpc/main.go
@@ -30,8 +30,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // this register the gzip compressor to the grpc server
-	"google.golang.org/grpc/health"
-	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -103,9 +101,6 @@ func run(flagset *flags) {
 	}
 	_, _ = fmt.Fprintln(os.Stdout, string(bytes))
 	testrpc.RegisterTestServiceServer(server, interopgrpc.NewTestServer())
-	healthServer := health.NewServer()
-	healthServer.SetServingStatus(testrpc.TestService_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(server, healthServer)
 	_ = server.Serve(lis)
 	defer server.GracefulStop()
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,9 @@ services:
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
       - ./cert:/cert/:ro
+    depends_on:
+      - server-connect
+      - server-grpc
   client-connect-to-server-connect-h1:
     build:
       context: .
@@ -165,7 +168,6 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="connect-grpc-web"
     depends_on:
-      - server-connect
       - envoy
   client-web-connect-grpc-web-to-envoy-server-grpc:
     build:
@@ -176,7 +178,6 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="connect-grpc-web"
     depends_on:
-      - server-grpc
       - envoy
   client-web-grpc-web-to-server-connect-h1:
     build:
@@ -197,7 +198,6 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="grpc-web"
     depends_on:
-      - server-connect
       - envoy
   client-web-grpc-web-to-envoy-server-grpc:
     build:
@@ -208,5 +208,4 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="grpc-web"
     depends_on:
-      - server-grpc
       - envoy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,11 +11,6 @@ services:
       - "8080:8080"
       - "8081:8081"
       - "8082:8082"
-    healthcheck:
-      test: [ "CMD", "/usr/local/bin/grpc-health-probe", "-addr=localhost:8081", "-service=grpc.testing.TestService", "-tls", "-tls-ca-cert=cert/CrosstestCA.crt", "-tls-server-name=server-connect"]
-      interval: 1s
-      timeout: 1s
-      retries: 5
   server-grpc:
     build:
       context: .
@@ -25,11 +20,6 @@ services:
     entrypoint: /usr/local/bin/servergrpc --port "8083" --cert "cert/server-grpc.crt" --key "cert/server-grpc.key"
     ports:
       - "8083:8083"
-    healthcheck:
-      test: [ "CMD", "/usr/local/bin/grpc-health-probe", "-addr=localhost:8083", "-service=grpc.testing.TestService", "-tls", "-tls-ca-cert=cert/CrosstestCA.crt", "-tls-server-name=server-grpc"]
-      interval: 1s
-      timeout: 1s
-      retries: 5
   envoy:
     image: envoyproxy/envoy:v1.20-latest
     ports:
@@ -38,11 +28,6 @@ services:
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
       - ./cert:/cert/:ro
-    depends_on:
-      server-connect:
-        condition: service_healthy
-      server-grpc:
-        condition: service_healthy
   client-connect-to-server-connect-h1:
     build:
       context: .
@@ -51,8 +36,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8080" --implementation="connect-h1" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-to-server-connect-h2:
     build:
       context: .
@@ -61,8 +45,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-to-server-connect-h3:
     build:
       context: .
@@ -71,8 +54,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-to-server-connect-h1:
     build:
       context: .
@@ -81,8 +63,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8080" --implementation="connect-grpc-h1" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-to-server-connect-h2:
     build:
       context: .
@@ -91,8 +72,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-grpc-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-to-server-connect-h3:
     build:
       context: .
@@ -101,8 +81,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-grpc-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-web-to-server-connect-h1:
     build:
       context: .
@@ -111,8 +90,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8080" --implementation="connect-grpc-web-h1" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-web-to-server-connect-h2:
     build:
       context: .
@@ -121,8 +99,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-grpc-web-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-web-to-server-connect-h3:
     build:
       context: .
@@ -131,8 +108,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-grpc-web-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-connect-grpc-to-server-grpc:
     build:
       context: .
@@ -141,8 +117,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-grpc" --port="8083" --implementation="connect-grpc-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-grpc:
-        condition: service_healthy
+      - server-grpc
   client-grpc-to-server-connect:
     build:
       context: .
@@ -151,8 +126,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="grpc-go" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-grpc-to-server-grpc:
     build:
       context: .
@@ -161,8 +135,7 @@ services:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/client --host="server-grpc" --port="8083" --implementation="grpc-go" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
-      server-grpc:
-        condition: service_healthy
+      - server-grpc
   client-web-connect-web-to-server-connect-h1:
     build:
       context: .
@@ -172,8 +145,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="server-connect" --port="8080" --implementation="connect-web"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-web-connect-grpc-web-to-server-connect-h1:
     build:
       context: .
@@ -183,8 +155,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="server-connect" --port="8080" --implementation="connect-grpc-web"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-web-connect-grpc-web-to-envoy-server-connect:
     build:
       context: .
@@ -194,6 +165,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="connect-grpc-web"
     depends_on:
+      - server-connect
       - envoy
   client-web-connect-grpc-web-to-envoy-server-grpc:
     build:
@@ -204,6 +176,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="connect-grpc-web"
     depends_on:
+      - server-grpc
       - envoy
   client-web-grpc-web-to-server-connect-h1:
     build:
@@ -214,8 +187,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="server-connect" --port="8080" --implementation="grpc-web"
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect
   client-web-grpc-web-to-envoy-server-connect:
     build:
       context: .
@@ -225,6 +197,7 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9091" --implementation="grpc-web"
     depends_on:
+      - server-connect
       - envoy
   client-web-grpc-web-to-envoy-server-grpc:
     build:
@@ -235,4 +208,5 @@ services:
         TEST_CONNECT_WEB_BRANCH: "${TEST_CONNECT_WEB_BRANCH:-}"
     entrypoint: npm run test -- --docker --host="envoy" --port="9092" --implementation="grpc-web"
     depends_on:
+      - server-grpc
       - envoy

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/bufbuild/connect-go v0.3.0
-	github.com/bufbuild/connect-grpchealth-go v0.1.0
 	github.com/lucas-clemente/quic-go v0.28.1
 	github.com/rs/cors v1.8.2
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bufbuild/connect-go v0.3.0 h1:B0vyZrTR11SNEYpodL6P0NzluDCsuqmr8CNKblXvVto=
 github.com/bufbuild/connect-go v0.3.0/go.mod h1:4efZ2eXFENwd4p7tuLaL9m0qtTsCOzuBvrohvRGevDM=
-github.com/bufbuild/connect-grpchealth-go v0.1.0 h1:r3HMBCXkqocR7z1ET98kteRE5K4B84lP9XMCRQXIGmw=
-github.com/bufbuild/connect-grpchealth-go v0.1.0/go.mod h1:Vm0Mk9/DurVa0pThTknZTXTzzfNio6EDpU64SP4JONc=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
the health check tool `grpc-health-probe` gave us some overhead to manage in docker image as we are building it in multiple platforms and need cross compiling ([failed CI](https://github.com/bufbuild/connect-crosstest/actions/runs/2828961240)). that's definitely something we can manage, but considering that the main cause of the flaky test seems to be the envoy's DNS resolution problem, the health check might be unnecessary at all. I think it makes sense for us to revert the health check for now and observe if the issue still happen with the envoy's dependencies changes, and we can bring the health check back in that case