### PR TITLE
reenable connect grpc-web to connect http3 server test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ dockercomposetestgo: dockercomposeclean
 	docker-compose run client-connect-grpc-to-server-connect-h2
 	docker-compose run client-connect-grpc-web-to-server-connect-h1
 	docker-compose run client-connect-grpc-web-to-server-connect-h2
+	docker-compose run client-connect-grpc-web-to-server-connect-h3
 	docker-compose run client-connect-grpc-to-server-grpc
 	docker-compose run client-grpc-to-server-connect
 	docker-compose run client-grpc-to-server-grpc

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -195,7 +195,7 @@ func run(flags *flags) {
 
 	// run tests base on the implementation
 	switch flags.implementation {
-	// We skipped those streaming tests for http 1 test
+	// We skipped those client and bidi streaming tests for http 1 test
 	case connectH1, connectGRPCH1, connectGRPCWebH1:
 		for _, client := range []testingconnect.TestServiceClient{uncompressedClient, compressedClient} {
 			testConnectUnary(client)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -225,7 +225,7 @@ func run(flags *flags) {
 		for _, client := range []testingconnect.TestServiceClient{uncompressedClient, compressedClient} {
 			// For tests that depend on trailers, we only run them for HTTP2, since the HTTP3 client
 			// does not yet have trailers support https://github.com/lucas-clemente/quic-go/issues/2266
-			// Once trailer support is available, they will be renabled.
+			// Once trailer support is available, they will be reenabled.
 			interopconnect.DoEmptyUnaryCall(console.NewTB(), client)
 			interopconnect.DoLargeUnaryCall(console.NewTB(), client)
 			interopconnect.DoClientStreaming(console.NewTB(), client)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,15 +76,6 @@ services:
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8081" --implementation="connect-grpc-h2" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
       - server-connect
-  client-connect-grpc-to-server-connect-h3:
-    build:
-      context: .
-      dockerfile: Dockerfile.crosstest
-      args:
-        TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
-    entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-grpc-h3" --cert "cert/client.crt" --key "cert/client.key"
-    depends_on:
-      - server-connect
   client-connect-grpc-web-to-server-connect-h1:
     build:
       context: .


### PR DESCRIPTION
from the discussion [here](https://github.com/bufbuild/connect-crosstest/pull/156#discussion_r893897936) seems like we actually want to keep the connect grpc-web to connect http3 server test, but end up still removed from the make target, this added the test back. Also included some cleanup and comment update