### PR TITLE
fix NPM dependencies issue when testing branch on protobuf-es

### DIFF
--- a/Dockerfile.crosstestweb
+++ b/Dockerfile.crosstestweb
@@ -15,14 +15,16 @@ COPY web/spec /workspace/spec
 RUN npm install
 RUN local_npm_packages="" && \
     if [ ! -z "${TEST_PROTOBUF_ES_BRANCH}" ]; then \
-        git clone --branch "${TEST_PROTOBUF_ES_BRANCH}" --depth 1 https://github.com/bufbuild/protobuf-es.git && \
-        npm --prefix ./protobuf-es/packages/protobuf/ run build && \
-        local_npm_packages="${local_npm_packages} ./protobuf-es/packages/protobuf/"; \
+        git clone --branch "${TEST_PROTOBUF_ES_BRANCH}" --depth 1 https://github.com/bufbuild/protobuf-es.git ../protobuf-es && \
+        npm --prefix ../protobuf-es install --ignore-script esbuild && \
+        npm --prefix ../protobuf-es -w @bufbuild/protobuf run build && \
+        local_npm_packages="${local_npm_packages} ../protobuf-es/packages/protobuf/"; \
     fi && \
     if [ ! -z "${TEST_CONNECT_WEB_BRANCH}" ]; then \
-        git clone --branch "${TEST_CONNECT_WEB_BRANCH}" --depth 1 https://github.com/bufbuild/connect-web.git && \
-        npm --prefix ./connect-web/packages/connect-web/ run build && \
-        local_npm_packages="${local_npm_packages} ./connect-web/packages/connect-web/"; \
+        git clone --branch "${TEST_CONNECT_WEB_BRANCH}" --depth 1 https://github.com/bufbuild/connect-web.git ../connect-web && \
+        npm --prefix ../connect-web install && \
+        npm --prefix ../connect-web -w @bufbuild/connect-web run build && \
+        local_npm_packages="${local_npm_packages} ../connect-web/packages/connect-web/"; \
     fi && \
     if [ ! -z "${local_npm_packages}" ]; then \
         npm link ${local_npm_packages}; \

--- a/Dockerfile.crosstestweb
+++ b/Dockerfile.crosstestweb
@@ -16,7 +16,7 @@ RUN npm install
 RUN local_npm_packages="" && \
     if [ ! -z "${TEST_PROTOBUF_ES_BRANCH}" ]; then \
         git clone --branch "${TEST_PROTOBUF_ES_BRANCH}" --depth 1 https://github.com/bufbuild/protobuf-es.git ../protobuf-es && \
-        npm --prefix ../protobuf-es install --ignore-script esbuild && \
+        npm --prefix ../protobuf-es install && \
         npm --prefix ../protobuf-es -w @bufbuild/protobuf run build && \
         local_npm_packages="${local_npm_packages} ../protobuf-es/packages/protobuf/"; \
     fi && \

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,13 +10,13 @@
       "dependencies": {
         "@bufbuild/connect-web": "^0.1.0",
         "@bufbuild/protobuf": "^0.0.10",
-        "@types/karma": "^6.3.3",
         "prettier": "^2.7.1"
       },
       "devDependencies": {
         "@types/caseless": "^0.12.2",
         "@types/google-protobuf": "^3.15.6",
         "@types/jasmine": "^4.0.3",
+        "@types/karma": "^6.3.3",
         "@typescript-eslint/eslint-plugin": "^5.34.0",
         "@typescript-eslint/parser": "^5.34.0",
         "caseless": "^0.12.0",
@@ -194,6 +194,7 @@
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@types/karma/-/karma-6.3.3.tgz",
       "integrity": "sha512-nRMec4mTCt+tkpRqh5/pAxmnjzEgAaalIq7mdfLFH88gSRC8+bxejLiSjHMMT/vHIhJHqg4GPIGCnCFbwvDRww==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "log4js": "^6.4.1"
@@ -202,7 +203,8 @@
     "node_modules/@types/node": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
-      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.34.0",
@@ -775,6 +777,7 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
       "integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -783,6 +786,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1727,7 +1731,8 @@
     "node_modules/flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
     },
     "node_modules/follow-redirects": {
       "version": "1.14.9",
@@ -1753,6 +1758,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1893,7 +1899,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -2157,6 +2164,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2313,6 +2321,7 @@
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
       "integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
+      "dev": true,
       "dependencies": {
         "date-format": "^4.0.9",
         "debug": "^4.3.4",
@@ -2433,7 +2442,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2775,7 +2785,8 @@
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -2936,6 +2947,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
       "integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
+      "dev": true,
       "dependencies": {
         "date-format": "^4.0.9",
         "debug": "^4.3.4",
@@ -3116,6 +3128,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3463,6 +3476,7 @@
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@types/karma/-/karma-6.3.3.tgz",
       "integrity": "sha512-nRMec4mTCt+tkpRqh5/pAxmnjzEgAaalIq7mdfLFH88gSRC8+bxejLiSjHMMT/vHIhJHqg4GPIGCnCFbwvDRww==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "log4js": "^6.4.1"
@@ -3471,7 +3485,8 @@
     "@types/node": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
-      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.34.0",
@@ -3878,12 +3893,14 @@
     "date-format": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
-      "integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg=="
+      "integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4517,7 +4534,8 @@
     "flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.14.9",
@@ -4529,6 +4547,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4632,7 +4651,8 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -4838,6 +4858,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -4965,6 +4986,7 @@
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
       "integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
+      "dev": true,
       "requires": {
         "date-format": "^4.0.9",
         "debug": "^4.3.4",
@@ -5052,7 +5074,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5277,7 +5300,8 @@
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -5391,6 +5415,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
       "integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
+      "dev": true,
       "requires": {
         "date-format": "^4.0.9",
         "debug": "^4.3.4",
@@ -5508,7 +5533,8 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,13 +12,13 @@
   "dependencies": {
     "@bufbuild/connect-web": "^0.1.0",
     "@bufbuild/protobuf": "^0.0.10",
-    "@types/karma": "^6.3.3",
     "prettier": "^2.7.1"
   },
   "devDependencies": {
     "@types/caseless": "^0.12.2",
     "@types/google-protobuf": "^3.15.6",
     "@types/jasmine": "^4.0.3",
+    "@types/karma": "^6.3.3",
     "@typescript-eslint/eslint-plugin": "^5.34.0",
     "@typescript-eslint/parser": "^5.34.0",
     "caseless": "^0.12.0",


### PR DESCRIPTION
after the changes here https://github.com/bufbuild/protobuf-es/pull/198 we need to take care of the dependencies on protobuf-es when testing branch as the build script use the tsc in the node_modules now. In fact the original way of cloning and linking the protobuf-es and connect-web here in `connect-crosstest` bring nested packages.json and node_modules in the dockerfile, which is not ideal, so this PR fixed both of them
