### PR TITLE
Disable goimports, rely on gci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
+    - goimports         # rely on gci instead
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author


### PR DESCRIPTION
We're already running GCI (since we enable all Go linters by default),
so we don't need `goimports`. We're making a similar change in core,
bufbuild/buf, and all our other Go repositories.
