### PR TITLE
add connect grpc-web client to envoy server tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ dockercomposetestgo: dockercomposeclean
 	docker-compose run client-connect-grpc-web-to-server-connect-h1
 	docker-compose run client-connect-grpc-web-to-server-connect-h2
 	docker-compose run client-connect-grpc-web-to-server-connect-h3
+	docker-compose run client-connect-grpc-web-to-envoy-server-connect-h1
+	docker-compose run client-connect-grpc-web-to-envoy-server-grpc-h1
 	docker-compose run client-connect-grpc-to-server-grpc
 	docker-compose run client-grpc-to-server-connect
 	docker-compose run client-grpc-to-server-grpc

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,24 @@ services:
     entrypoint: /usr/local/bin/client --host="server-connect" --port="8082" --implementation="connect-grpc-web-h3" --cert "cert/client.crt" --key "cert/client.key"
     depends_on:
       - server-connect
+  client-connect-grpc-web-to-envoy-server-connect-h1:
+    build:
+      context: .
+      dockerfile: Dockerfile.crosstest
+      args:
+        TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
+    entrypoint: /usr/local/bin/client --host="envoy" --port="9091" --implementation="connect-grpc-web-h1" --cert "cert/client.crt" --key "cert/client.key"
+    depends_on:
+      - envoy
+  client-connect-grpc-web-to-envoy-server-grpc-h1:
+    build:
+      context: .
+      dockerfile: Dockerfile.crosstest
+      args:
+        TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
+    entrypoint: /usr/local/bin/client --host="envoy" --port="9092" --implementation="connect-grpc-web-h1" --cert "cert/client.crt" --key "cert/client.key"
+    depends_on:
+      - envoy
   client-connect-grpc-to-server-grpc:
     build:
       context: .


### PR DESCRIPTION
while upgrading the dependencies, I noticed that we don't have tests for connect-go's client with grpc-web protocol to connect and grpc server via envoy 😐
