### PR TITLE
Fix crosstest-web workflow against branch

### DIFF
--- a/Dockerfile.crosstestweb
+++ b/Dockerfile.crosstestweb
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 WORKDIR /workspace
 
@@ -7,7 +7,9 @@ ARG TEST_CONNECT_WEB_BRANCH
 ENV CHROME_BIN /usr/bin/chromium-browser
 RUN apk add --update --no-cache \
     chromium \
-    git
+    git \
+    make \
+    bash
 COPY web/package.json web/package-lock.json /workspace/
 COPY web/tsconfig.json web/karma.conf.js /workspace/
 COPY web/gen /workspace/gen


### PR DESCRIPTION
This adds `make` and `bash` to the dockerfile, so we can build @bufbuild/connect-web from a branch.

Verified with:

```bash
make dockercomposeclean && TEST_CONNECT_WEB_BRANCH=tstamm/update-buf make dockercomposetestweb
```

After https://github.com/bufbuild/connect-es/pull/501 is merged, this will work with branch `main`.