### PR TITLE
Honor context errors in the grpc-go server

### DIFF
--- a/internal/interop/interopgrpc/test_server.go
+++ b/internal/interop/interopgrpc/test_server.go
@@ -158,8 +158,8 @@ func (s *testServer) StreamingOutputCall(args *testpb.StreamingOutputCallRequest
 		}
 	}
 	cs := args.GetResponseParameters()
-	for _, c := range cs {
-		if us := c.GetIntervalUs(); us > 0 {
+	for _, responseParameter := range cs {
+		if us := responseParameter.GetIntervalUs(); us > 0 {
 			time.Sleep(time.Duration(us) * time.Microsecond)
 		}
 		// Checking if the context is canceled or deadline exceeded, in a real world usage it will
@@ -168,7 +168,7 @@ func (s *testServer) StreamingOutputCall(args *testpb.StreamingOutputCallRequest
 		if err := stream.Context().Err(); err != nil {
 			return err
 		}
-		pl, err := serverNewPayload(args.GetResponseType(), c.GetSize())
+		pl, err := serverNewPayload(args.GetResponseType(), responseParameter.GetSize())
 		if err != nil {
 			return err
 		}
@@ -186,8 +186,8 @@ func (s *testServer) StreamingOutputCall(args *testpb.StreamingOutputCallRequest
 
 func (s *testServer) FailStreamingOutputCall(args *testpb.StreamingOutputCallRequest, stream testpb.TestService_FailStreamingOutputCallServer) error {
 	cs := args.GetResponseParameters()
-	for _, c := range cs {
-		if us := c.GetIntervalUs(); us > 0 {
+	for _, responseParameter := range cs {
+		if us := responseParameter.GetIntervalUs(); us > 0 {
 			time.Sleep(time.Duration(us) * time.Microsecond)
 		}
 		// Checking if the context is canceled or deadline exceeded, in a real world usage it will
@@ -196,7 +196,7 @@ func (s *testServer) FailStreamingOutputCall(args *testpb.StreamingOutputCallReq
 		if err := stream.Context().Err(); err != nil {
 			return err
 		}
-		pl, err := serverNewPayload(args.GetResponseType(), c.GetSize())
+		pl, err := serverNewPayload(args.GetResponseType(), responseParameter.GetSize())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We had to disable the `timeout_on_sleeping_server` test in connect-es some time ago because it failed against the crosstest grpc-go server. In this test, the clients calls a server with a short timeout and asks it to sleep. The expected outcome is a deadline exceeded error.

Looking into this, I noticed that we are checking for context errors in the StreamingOutputCall RPC - after the sleep, before we send a response message - [in connect-go](https://github.com/bufbuild/connect-crosstest/blob/18528e0c1b5f9bd2cfcf919012ffdf89f737216b/internal/interop/interopconnect/test_server.go#L99). But we are missing a similar check in the grpc-go implementation. 

Because of this, the test case only passes only for very short timeouts, but since the shortest possible timeout to be specified in JS is 1ms, this is flaky. The most recent failure of the [cross-test web run](https://github.com/bufbuild/connect-crosstest/actions/runs/4574039988/jobs/8075191837) was most likely caused by this.

I can reproduce the error consistently locally, with a 1s timeout and a 4s sleep interval. With this PR, the server behaves as expected.

This PR adds context checks not only to the StreamingOutputCall RPC, but also at all other places where the context is checked in the connect-go implementation.