### PR TITLE
Update to Go 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.19.x,1.20.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -39,6 +39,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
       - name: Lint
+        if: matrix.go-version == '1.20.x'
         run: make lint && make checkgenerate
   docker:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 
 $(BIN)/protoc-gen-connect-go: Makefile go.mod
 	@mkdir -p $(@D)

--- a/internal/interop/interop.go
+++ b/internal/interop/interop.go
@@ -20,7 +20,7 @@ import testpb "github.com/bufbuild/connect-crosstest/internal/gen/proto/go/grpc/
 const NonASCIIErrMsg = "soirée 🎉" // readable non-ASCII
 
 // ErrorDetail is an error detail to be included in an error.
-var ErrorDetail = &testpb.ErrorDetail{
+var ErrorDetail = &testpb.ErrorDetail{ //nolint:gochecknoglobals
 	Reason: NonASCIIErrMsg,
 	Domain: "connect-crosstest",
 }


### PR DESCRIPTION
The old version of golangci-linter does not work with Go 1.20. For consistency, let's sync it with connect-go.