### PR TITLE
Add missing CORS exposed headers for GET

### DIFF
--- a/cmd/serverconnect/main.go
+++ b/cmd/serverconnect/main.go
@@ -114,7 +114,7 @@ func run(flags *flags) {
 		// name "*" without special semantics.
 		ExposedHeaders: []string{
 			"Grpc-Status", "Grpc-Message", "Grpc-Status-Details-Bin", "X-Grpc-Test-Echo-Initial",
-			"Trailer-X-Grpc-Test-Echo-Trailing-Bin"},
+			"Trailer-X-Grpc-Test-Echo-Trailing-Bin", "Request-Protocol", "Get-Request"},
 	}).Handler(mux)
 	tlsConfig := newTLSConfig(flags.certFile, flags.keyFile)
 	h1Server := http.Server{


### PR DESCRIPTION
This is breaking my tests right now for `connect-es` cacheable unary support.