### PR TITLE
Add additional check for Fetch API duplicate headers

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -137,7 +137,7 @@ func run(flags *flags) {
 	}
 
 	// tests for connect clients
-	serverURL, err := url.ParseRequestURI("https://" + net.JoinHostPort(flags.host, flags.port))
+	serverURL, err := url.ParseRequestURI("http://" + net.JoinHostPort(flags.host, flags.port))
 	if err != nil {
 		log.Fatalf("invalid url: %s", "https://"+net.JoinHostPort(flags.host, flags.port))
 	}
@@ -146,9 +146,7 @@ func run(flags *flags) {
 	var transport http.RoundTripper
 	switch flags.implementation {
 	case connectH1, connectGRPCH1, connectGRPCWebH1:
-		transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
+		transport = &http.Transport{}
 	case connectGRPCH2, connectH2, connectGRPCWebH2:
 		transport = &http2.Transport{
 			TLSClientConfig: tlsConfig,

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -137,7 +137,7 @@ func run(flags *flags) {
 	}
 
 	// tests for connect clients
-	serverURL, err := url.ParseRequestURI("http://" + net.JoinHostPort(flags.host, flags.port))
+	serverURL, err := url.ParseRequestURI("https://" + net.JoinHostPort(flags.host, flags.port))
 	if err != nil {
 		log.Fatalf("invalid url: %s", "https://"+net.JoinHostPort(flags.host, flags.port))
 	}
@@ -146,7 +146,9 @@ func run(flags *flags) {
 	var transport http.RoundTripper
 	switch flags.implementation {
 	case connectH1, connectGRPCH1, connectGRPCWebH1:
-		transport = &http.Transport{}
+		transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
 	case connectGRPCH2, connectH2, connectGRPCWebH2:
 		transport = &http2.Transport{
 			TLSClientConfig: tlsConfig,

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -298,6 +298,9 @@ func validateMetadata(
 	expectedStringHeaders map[string][]string,
 	expectedBinaryHeaders map[string][][]byte,
 ) {
+	fmt.Println("Using a canonical header: ", trailer.Values("X-Grpc-Test-Echo-Trailing-Bin"))
+	fmt.Println("Using all lowercase: ", trailer.Values("x-grpc-test-echo-trailing-bin"))
+	fmt.Println("Using the map directly: ", trailer["x-grpc-test-echo-trailing-bin"])
 	for key, values := range expectedStringHeaders {
 		actualValues := header.Values(key)
 		// If the returned header values are not equal to what we expect, next check whether the header
@@ -318,11 +321,6 @@ func validateMetadata(
 		}
 	}
 	for key, values := range expectedBinaryHeaders {
-		fmt.Println("expected trailers key ", key)
-		fmt.Println("expected trailer values ", values)
-		fmt.Println("expected trailer values len", len(values))
-		fmt.Println("actual trailer values ", trailer.Values(key))
-		fmt.Println("actual trailer values len", len(trailer.Values(key)))
 		actualValues := trailer.Values(key)
 		// If the returned trailer values are not equal to what we expect, next check whether the trailer
 		// values were combined into one comma-delimited string. The Fetch API Headers object will return
@@ -346,6 +344,7 @@ func validateMetadata(
 
 // DoCustomMetadataUnary checks that metadata is echoed back to the client with unary call.
 func DoCustomMetadataUnary(t crosstesting.TB, client connectpb.TestServiceClient) {
+	fmt.Println("DoCustomMetadataUnary")
 	customMetadataUnaryTest(
 		t,
 		client,

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -301,6 +301,9 @@ func validateMetadata(
 	for key, values := range expectedStringHeaders {
 		actualValues := header.Values(key)
 		// The server may have combined multiple lines for a field to a single line, see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3
+		// This is not a complete semantic comparison as it doesn't cover all possible cases. For example:
+		// Foo: a
+		// Foo: b, c, d
 		if len(values) != len(actualValues) && len(actualValues) == 1 {
 			actualValues = strings.Split(actualValues[0], ", ")
 		}
@@ -318,6 +321,10 @@ func validateMetadata(
 	for key, values := range expectedBinaryHeaders {
 		actualValues := trailer.Values(key)
 		// The server may have combined multiple lines for a field to a single line, see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3
+		// This is not a complete semantic comparison as it doesn't cover all possible cases. For example:
+		// Foo: a
+		// Foo: b, c, d
+		if len(values) != len(actualValues) && len(actualValues) == 1 {
 			actualValues = strings.Split(actualValues[0], ", ")
 		}
 		assert.Equal(t, len(values), len(actualValues))

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -300,9 +300,7 @@ func validateMetadata(
 ) {
 	for key, values := range expectedStringHeaders {
 		actualValues := header.Values(key)
-		// If the returned header values are not equal to what we expect, next check whether the header
-		// values were combined into one comma-delimited string. The Fetch API Headers object will return
-		// duplicate headers this way.
+		// The server may have combined multiple lines for a field to a single line, see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3
 		if len(values) != len(actualValues) && len(actualValues) == 1 {
 			actualValues = strings.Split(actualValues[0], ", ")
 		}

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -319,10 +319,7 @@ func validateMetadata(
 	}
 	for key, values := range expectedBinaryHeaders {
 		actualValues := trailer.Values(key)
-		// If the returned trailer values are not equal to what we expect, next check whether the trailer
-		// values were combined into one comma-delimited string. The Fetch API Headers object will return
-		// duplicate headers this way.
-		if len(values) != len(actualValues) && len(actualValues) == 1 {
+		// The server may have combined multiple lines for a field to a single line, see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3
 			actualValues = strings.Split(actualValues[0], ", ")
 		}
 		assert.Equal(t, len(values), len(actualValues))

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -160,16 +160,6 @@ func DoServerStreaming(t crosstesting.TB, client connectpb.TestServiceClient) {
 		index++
 		respCnt++
 	}
-	if stream.Err() != nil {
-		if connectErr := new(connect.Error); errors.As(stream.Err(), &connectErr) {
-			fmt.Println("Code: ", connectErr.Code())
-			fmt.Println("Message: ", connectErr.Message())
-			fmt.Println("Details: ", connectErr.Details())
-			fmt.Println("Metadata: ", connectErr.Meta())
-			fmt.Println("Acme: ", connectErr.Meta().Values("acme-operation-cost"))
-		}
-	}
-
 	require.NoError(t, stream.Err())
 	require.NoError(t, stream.Close())
 	assert.Equal(t, respCnt, len(respSizes))

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -160,6 +160,16 @@ func DoServerStreaming(t crosstesting.TB, client connectpb.TestServiceClient) {
 		index++
 		respCnt++
 	}
+	if stream.Err() != nil {
+		if connectErr := new(connect.Error); errors.As(stream.Err(), &connectErr) {
+			fmt.Println("Code: ", connectErr.Code())
+			fmt.Println("Message: ", connectErr.Message())
+			fmt.Println("Details: ", connectErr.Details())
+			fmt.Println("Metadata: ", connectErr.Meta())
+			fmt.Println("Acme: ", connectErr.Meta().Values("acme-operation-cost"))
+		}
+	}
+
 	require.NoError(t, stream.Err())
 	require.NoError(t, stream.Close())
 	assert.Equal(t, respCnt, len(respSizes))
@@ -298,9 +308,6 @@ func validateMetadata(
 	expectedStringHeaders map[string][]string,
 	expectedBinaryHeaders map[string][][]byte,
 ) {
-	fmt.Println("Using a canonical header: ", trailer.Values("X-Grpc-Test-Echo-Trailing-Bin"))
-	fmt.Println("Using all lowercase: ", trailer.Values("x-grpc-test-echo-trailing-bin"))
-	fmt.Println("Using the map directly: ", trailer["x-grpc-test-echo-trailing-bin"])
 	for key, values := range expectedStringHeaders {
 		actualValues := header.Values(key)
 		// If the returned header values are not equal to what we expect, next check whether the header
@@ -344,7 +351,6 @@ func validateMetadata(
 
 // DoCustomMetadataUnary checks that metadata is echoed back to the client with unary call.
 func DoCustomMetadataUnary(t crosstesting.TB, client connectpb.TestServiceClient) {
-	fmt.Println("DoCustomMetadataUnary")
 	customMetadataUnaryTest(
 		t,
 		client,
@@ -359,7 +365,6 @@ func DoCustomMetadataUnary(t crosstesting.TB, client connectpb.TestServiceClient
 }
 
 func DoCustomMetadataServerStreaming(t crosstesting.TB, client connectpb.TestServiceClient) {
-	fmt.Println("DoCustomMetadataServerStreaming")
 	customMetadataServerStreamingTest(
 		t,
 		client,
@@ -375,7 +380,6 @@ func DoCustomMetadataServerStreaming(t crosstesting.TB, client connectpb.TestSer
 
 // DoCustomMetadataFullDuplex checks that metadata is echoed back to the client with full duplex call.
 func DoCustomMetadataFullDuplex(t crosstesting.TB, client connectpb.TestServiceClient) {
-	fmt.Println("DoCustomMetadataFullDuplex")
 	customMetadataFullDuplexTest(
 		t,
 		client,
@@ -392,7 +396,6 @@ func DoCustomMetadataFullDuplex(t crosstesting.TB, client connectpb.TestServiceC
 // DoDuplicatedCustomMetadataUnary adds duplicated metadata keys and checks that the metadata is echoed back
 // to the client with unary call.
 func DoDuplicatedCustomMetadataUnary(t crosstesting.TB, client connectpb.TestServiceClient) {
-	fmt.Println("DoDuplicatedCustomMetadataUnary")
 	customMetadataUnaryTest(
 		t,
 		client,
@@ -407,7 +410,6 @@ func DoDuplicatedCustomMetadataUnary(t crosstesting.TB, client connectpb.TestSer
 }
 
 func DoDuplicatedCustomMetadataServerStreaming(t crosstesting.TB, client connectpb.TestServiceClient) {
-	fmt.Println("DoDuplicatedCustomMetadataServerStreaming")
 	customMetadataServerStreamingTest(
 		t,
 		client,


### PR DESCRIPTION
This adds an additional check for any duplicate headers that may have been set by the Fetch API. The `Headers` object will concatenate duplicate header values into one comma-delimited string. As a result, this was causing the tests to fail for any client hitting a Node server using this `Headers` object.