### PR TITLE
Fix CI for docker publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: docker-build-push
         uses: docker/build-push-action@v3
         with:
-          file: Dockerfile.crosstest
+          file: Dockerfile.crosstestgo
           platforms: ${{ steps.qemu.outputs.platforms }}
           push: true
           tags: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,3 +77,12 @@ jobs:
           tags: |
             bufbuild/connect-crosstest:latest
             bufbuild/connect-crosstest:${{ github.sha }}
+      - name: docker-build-push-web
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile.crosstestweb
+          platforms: ${{ steps.qemu.outputs.platforms }}
+          push: true
+          tags: |
+            bufbuild/connect-crosstest-web:latest
+            bufbuild/connect-crosstest-web:${{ github.sha }}


### PR DESCRIPTION
This updates the CI workflow to use the new name of the Dockerfile.crosstestgo docker file.

In addition, it adds another step for publishing Dockerfile.crosstestweb since that now has the ability to run a Node server.