### PR TITLE
Fix Dockerfile push for web image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,12 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - ci
-    # This job only runs when
-    # 1. The previous ci job has completed successfully
-    # 2. The repository is not a fork, i.e. it will only run on the official bufbuild/connect-crosstest
-    # 3. The workflow run is triggered by push to main branch
-    if:  ${{ success() && github.repository == 'bufbuild/connect-crosstest' && github.event_name == 'push' }}
-      && github.ref == 'refs/heads/main' }}
     steps:
       - name: setup-docker-buildx
         uses: docker/setup-buildx-action@v2
@@ -99,7 +93,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile.crosstestweb
-          platforms: ${{ steps.qemu.outputs.platforms }}
           push: true
           tags: |
             bufbuild/connect-crosstest-web:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
           tags: |
             bufbuild/connect-crosstest:latest
             bufbuild/connect-crosstest:${{ github.sha }}
+  # This job only runs when
   docker-web:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,13 @@ jobs:
     needs:
       - ci
     steps:
+      # qemu is used when executing things like `apk` in the final build
+      # stage which must execute on the target platform. We currently do
+      # not have any CGO and care should be taken in the Dockerfile to ensure
+      # that go cross compilation happens on the build platform.
+      - name: setup-qemu
+        uses: docker/setup-qemu-action@v2
+        id: qemu
       - name: setup-docker-buildx
         uses: docker/setup-buildx-action@v2
       - name: login-docker
@@ -91,7 +98,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: docker-build-push-web
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           file: Dockerfile.crosstestweb
           push: true


### PR DESCRIPTION
This removes the QEMU platform config for the Dockerhub push step.