### PR TITLE
Add c++ image with client tests and Docker Compose services

### DIFF
--- a/.github/workflows/crosstest-cc.yaml
+++ b/.github/workflows/crosstest-cc.yaml
@@ -1,0 +1,23 @@
+name: crosstest-cc
+on:
+  workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  crosstest-cc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Setup Docker Buildx # Docker Buildkit required for docker-compose
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+          install: true
+      - name: Test C++ gRPC Client
+        run: make dockercomposetestcc # Make target includes clean-up
+        env:
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1

--- a/Dockerfile.cc
+++ b/Dockerfile.cc
@@ -1,0 +1,11 @@
+FROM --platform=arm64 gcr.io/bazel-public/bazel
+
+ARG PORT
+ARG HOST
+ARG CERT_FILE
+ARG KEY_FILE
+WORKDIR /workspace
+COPY WORKSPACE.bazel .bazelrc /workspace/
+COPY cc /workspace/cc
+COPY proto /workspace/proto
+COPY cert /workspace/cert

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ dockercomposetestweb: dockercomposeclean
 
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
-	docker-compose run client-cc-grpc-to-server-connect-go-h1
-	docker-compose run client-cc-grpc-to-server-connect-go-h2
+	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
+	docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
 	$(MAKE) dockercomposeclean
 
 .PHONY: dockercomposetest

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,12 @@ dockercomposetestweb: dockercomposeclean
 	docker-compose run client-grpc-web-to-server-connect-node-fastify-h1
 	$(MAKE) dockercomposeclean
 
+.PHONY: dockercomposetestcc
+dockercomposetestcc: dockercomposeclean
+	docker-compose run client-cc-grpc-to-server-connect-go-h1
+	docker-compose run client-cc-grpc-to-server-connect-go-h2
+	$(MAKE) dockercomposeclean
+
 .PHONY: dockercomposetest
 dockercomposetest:
 	$(MAKE) dockercomposetestgo

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -366,3 +366,25 @@ services:
     depends_on:
       server-connect-node-fastify:
         condition: service_healthy
+  client-cc-grpc-to-server-connect-go-h1:
+    build:
+      context: .
+      dockerfile: Dockerfile.cc
+      args:
+        PORT: 8080
+        HOST: server-connect
+    entrypoint: bazel test //cc:grpc_client_test
+    depends_on:
+      - server-connect
+  client-cc-grpc-to-server-connect-go-h2:
+    build:
+      context: .
+      dockerfile: Dockerfile.cc
+      args:
+        PORT: 8080
+        HOST: server-connect
+        CERT_FILE: cert/client.crt
+        KEY_FILE: cert/client.key
+    entrypoint: bazel test //cc:grpc_client_test
+    depends_on:
+      - server-connect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -366,17 +366,17 @@ services:
     depends_on:
       server-connect-node-fastify:
         condition: service_healthy
-  client-cc-grpc-to-server-connect-go-h1:
+  client-cc-grpc-to-server-connect-go-h2-no-tls:
     build:
       context: .
       dockerfile: Dockerfile.cc
       args:
-        PORT: 8080
+        PORT: 8081
         HOST: server-connect
     entrypoint: bazel test //cc:grpc_client_test
     depends_on:
       - server-connect
-  client-cc-grpc-to-server-connect-go-h2:
+  client-cc-grpc-to-server-connect-go-h2-with-tls:
     build:
       context: .
       dockerfile: Dockerfile.cc

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -381,7 +381,7 @@ services:
       context: .
       dockerfile: Dockerfile.cc
       args:
-        PORT: 8080
+        PORT: 8081
         HOST: server-connect
         CERT_FILE: cert/client.crt
         KEY_FILE: cert/client.key


### PR DESCRIPTION
This adds a new Docker image for the C++ tests, Docker Compose services that run the
tests cases, a make target for them, and an on-demand Github Action.
There are two cases added to Docker Compose, one testing h2 without tls and the other with h2 + TLS.
The Docker image with Bazel is not the most performant when run locally, so I would
recommend running the jobs mostly in CI.